### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Parse, LLC.
 maintainer=Parse, LLC.
 sentence=A library that provides access to Parse
 paragraph=Provides convenience methods to access the REST API on Parse.com from Arduino.
+category=Communication
 url=https://github.com/ParsePlatform/parse-embedded-sdks
 architectures=avr,samd,esp8266


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Parse Arduino SDK is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.